### PR TITLE
Changed docker links to docker hub.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,5 +67,5 @@ Open localhost:5299/home or click the LazyLibrarian icon in the top left. Type a
 Auto update available via interface from master
 
 ## Docker packages
-x64 version here  : https://github.com/linuxserver/docker-lazylibrarian  
-armhf version here: https://github.com/linuxserver/docker-lazylibrarian-armhf   
+x64 version here  : https://hub.docker.com/r/linuxserver/lazylibrarian/  
+armhf version here: https://hub.docker.com/r/lsioarmhf/lazylibrarian/


### PR DESCRIPTION
Hey Phil, thanks for that, hope you don't mind but I've changed the links to the docker hub site where the images are pulled from.